### PR TITLE
fix: 修正後台query city參數獲取方式 ＆儀表板 API 請求

### DIFF
--- a/Taipei-City-Dashboard-FE/src/components/dialogs/AddComponent.vue
+++ b/Taipei-City-Dashboard-FE/src/components/dialogs/AddComponent.vue
@@ -33,6 +33,7 @@ async function handleSearch() {
 			pagesize: 100,
 			searchbyindex: searchIndex.value,
 			searchbyname: searchName.value,
+			city: contentStore.currentDashboard.city
 		},
 	});
 	allComponents.value = response.data.data;

--- a/Taipei-City-Dashboard-FE/src/components/dialogs/admin/AdminAddComponent.vue
+++ b/Taipei-City-Dashboard-FE/src/components/dialogs/admin/AdminAddComponent.vue
@@ -35,9 +35,10 @@ const availableComponents = computed(() => {
 async function handleSearch() {
 	const res = await http.get(`/component/`, {
 		params: {
-			pagesize: 100,
+			pagesize: 200,
 			searchbyindex: searchIndex.value,
 			searchbyname: searchName.value,
+			city: adminStore.currentCity,
 		},
 	});
 	allComponents.value = res.data.data;

--- a/Taipei-City-Dashboard-FE/src/components/dialogs/admin/AdminAddEditDashboards.vue
+++ b/Taipei-City-Dashboard-FE/src/components/dialogs/admin/AdminAddEditDashboards.vue
@@ -60,7 +60,6 @@ async function verifyIndex() {
 
 function handleConfirm() {
 	if (props.mode === "add") {
-		currentDashboard.value.city = city.value;
 		adminStore.addDashboard(currentDashboard.value);
 	} else if (props.mode === "edit") {
 		adminStore.editDashboard(currentDashboard.value);

--- a/Taipei-City-Dashboard-FE/src/components/utilities/forms/ComponentDragTags.vue
+++ b/Taipei-City-Dashboard-FE/src/components/utilities/forms/ComponentDragTags.vue
@@ -63,7 +63,6 @@ const handleDragEnd = () => {
     @dragend="handleDragEnd"
   >
     <h3>{{ tag.id }}</h3>
-    <p>{{ tag.city }}</p>
     <p>{{ tag.name }}</p>
     <button
       :style="{ backgroundColor: colorData ? tag : '' }"

--- a/Taipei-City-Dashboard-FE/src/router/index.js
+++ b/Taipei-City-Dashboard-FE/src/router/index.js
@@ -12,6 +12,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import { useContentStore } from "../store/contentStore";
 import { useMapStore } from "../store/mapStore";
 import { useAuthStore } from "../store/authStore";
+import { useAdminStore } from "../store/adminStore";
 import DashboardView from "../views/DashboardView.vue";
 import MapView from "../views/MapView.vue";
 import ComponentView from "../views/ComponentView.vue";
@@ -189,6 +190,16 @@ router.beforeEach((to) => {
 	// Clear only map layers if the path starts with /mapview
 	else if (to.path.toLowerCase() === "/mapview") {
 		mapStore.clearOnlyLayers();
+	}
+});
+
+// Handles admin related tasks (gets content for each route)
+router.beforeEach((to) => {
+	const adminStore = useAdminStore();
+	if (
+		to.path.toLowerCase() === "/admin/dashboard"
+	) {
+		adminStore.setRouteParams(to.query.city);
 	}
 });
 

--- a/Taipei-City-Dashboard-FE/src/store/adminStore.js
+++ b/Taipei-City-Dashboard-FE/src/store/adminStore.js
@@ -19,6 +19,7 @@ export const useAdminStore = defineStore("admin", {
 		dashboards: [],
 		taipeiDashboards: [],
 		metroTaipeiDashboards: [],
+		currentCity: "",
 		currentDashboard: null,
 		// Edit Component (for /admin/edit-component)
 		components: [],
@@ -51,22 +52,23 @@ export const useAdminStore = defineStore("admin", {
 			const contentStore = useContentStore();
 			contentStore.error = state ? true : false;
 		},
+		setRouteParams(city) {
+			this.currentCity = city;
+		},
 
 		/* Dashboard */
 		// 1. Get all public dashboards
 		async getDashboards() {
 			const response = await http.get(`/dashboard/`);
 			this.dashboards = response.data.data.public;
-			this.taipeiDashboards = response.data.data.taipei;
-			this.metroTaipeiDashboards = response.data.data.metrotaipei;
-
+			this.taipeiDashboards = response.data.data?.taipei || [];
+			this.metroTaipeiDashboards = response.data.data?.metrotaipei || [];
 			this.setLoading(false);
 		},
 		// 2. Get current dashboard components
-		async getCurrentDashboardComponents(city) {
-			this.currentDashboard.city = city;
+		async getCurrentDashboardComponents() {
 			const response = await http.get(
-				`/dashboard/${this.currentDashboard.index}`
+				`/dashboard/${this.currentDashboard.index}${this.currentCity ? `?city=${this.currentCity}` : ""}`
 			);
 			this.currentDashboard.components = response.data.data;
 			this.setLoading(false);
@@ -80,7 +82,7 @@ export const useAdminStore = defineStore("admin", {
 
 			const dashboard = JSON.parse(JSON.stringify(this.currentDashboard));
 
-			await http.post(`/dashboard/public`, dashboard);
+			await http.post(`/dashboard/public${this.currentCity ? `/${this.currentCity}` : ""}`, dashboard);
 			this.getDashboards();
 			dialogStore.showNotification("success", "公開儀表板新增成功");
 		},

--- a/Taipei-City-Dashboard-FE/src/views/admin/AdminDashboard.vue
+++ b/Taipei-City-Dashboard-FE/src/views/admin/AdminDashboard.vue
@@ -13,9 +13,8 @@ import AdminDeleteDashboard from "../../components/dialogs/admin/AdminDeleteDash
 const adminStore = useAdminStore();
 const dialogStore = useDialogStore();
 const contentStore = useContentStore();
-const route = useRoute();
 
-const dashboards = computed(()=> route.query.city === "taipei" ? adminStore.taipeiDashboards : adminStore.metroTaipeiDashboards);
+const dashboards = computed(()=> adminStore.currentCity === "taipei" ? adminStore.taipeiDashboards : adminStore.metroTaipeiDashboards);
 const dialogMode = ref("edit");
 
 function parseTime(time) {
@@ -27,7 +26,7 @@ function parseTime(time) {
 
 function handleOpenSettings(dashboard) {
 	adminStore.currentDashboard = JSON.parse(JSON.stringify(dashboard));
-	adminStore.getCurrentDashboardComponents(route.query.city);
+	adminStore.getCurrentDashboardComponents();
 	dialogMode.value = "edit";
 	dialogStore.showDialog("adminAddEditDashboards");
 }


### PR DESCRIPTION
- 將 query.city 統一改為透過 router.beforeEach 來獲取儲存在store的currentCity
- 新增儀表板時在路徑加入 city 參數，確保新增到對應的城市儀表板
- 獲取組件時加入 city 查詢參數，確保只存取當前城市的組件資料

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Summary

**Issue:** Enter the issue(s) this pull request resolves.

A clear and concise description of this pull request

## Type (Fill in "x" to check)

- [ ] Bug Fix
- [x] New Feature

## Checklist

Please make sure that all items are checked before submitting this request.

- [x] Code linter has been run and issues have all been resolved
- [x] The code has been thoroughly tested and no visible bugs have been introduced
- [x] The pull request will completely resolve the issue(s) mentioned
- [x] The pull request only resolves the issue(s) mentioned and nothing more

## Additional context

Add any other context here.
