### PR TITLE
fix(eoc_dashboard_controller): dashboard id 改由 sequence 配，不再寫死 96

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_dashboard_controller/eoc_dashboard_controller.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_dashboard_controller/eoc_dashboard_controller.py
@@ -296,7 +296,6 @@ def _transfer(**kwargs):
                             END;  
                         '''}
         }
-        dashboard_id = 96
         for pname in unique_names:
             print(f"處理 pname: {pname}")
             # 若 dashboard 已存在，直接結束排程
@@ -473,30 +472,28 @@ def _transfer(**kwargs):
             comp_ids = [int(x) for x in comp_ids]
 
             # 插入 dashboard 並帶上隨機 index、name=pname、components 會轉成 {x,y,z} 格式
-            dashboard_hook.run(
-                'INSERT INTO public.dashboards ("id", "index","name",components,icon,created_at,updated_at) '
-                'VALUES (%(dashboard_id)s,%(idx)s,%(name)s,%(components)s,%(icon)s,%(created_at)s,%(updated_at)s);',
+            # id 不可寫死：交給 dashboards_id_seq 配（與 BE 一致），
+            # 並在同一句 SQL 用 RETURNING 的 id 寫入 dashboard_groups，避免不同 run 重複用同一個 id
+            dashboard_id = dashboard_hook.run(
+                'WITH d AS ('
+                ' INSERT INTO public.dashboards ("index",name,components,icon,created_at,updated_at)'
+                ' VALUES (%(idx)s,%(name)s,%(components)s,%(icon)s,%(created_at)s,%(updated_at)s)'
+                ' RETURNING id'
+                ') '
+                'INSERT INTO public.dashboard_groups (dashboard_id, group_id) '
+                'SELECT id, %(group_id)s FROM d RETURNING dashboard_id;',
                 parameters={
-                    'dashboard_id': dashboard_id,
                     'idx': rand_idx,
                     'name': pname,
                     'components': comp_ids,
                     'icon': 'crisis_alert',
                     'created_at': datetime.now(timezone.utc),
-                    'updated_at': datetime.now(timezone.utc)
-                }
-            )
-            print(f"已建立/更新 dashboard: idx={rand_idx}, name={pname}, components={comp_ids}")
-
-            # group_id= 171 寫入dashboard_groups (維持 get_records + run)
-
-            dashboard_hook.run(
-                    'INSERT INTO public.dashboard_groups (dashboard_id, group_id) '
-                    'VALUES (%(dashboard_id)s, 171) ON CONFLICT DO NOTHING;',
-                    parameters={'dashboard_id': dashboard_id}
-                )
-            print(f"已建立 dashboard_groups 關聯: dashboard_id={dashboard_id}, group_id={group_id}")
-            dashboard_id += 1  # 每次建立後遞增 dashboard_id
+                    'updated_at': datetime.now(timezone.utc),
+                    'group_id': group_id
+                },
+                handler=lambda cur: cur.fetchone()
+            )[0]
+            print(f"已建立 dashboard: id={dashboard_id}, idx={rand_idx}, name={pname}, components={comp_ids}, group_id={group_id}")
 
     # except Exception as e:
     #     print(f"執行過程中發生錯誤: {e}")


### PR DESCRIPTION
## 問題

`eoc_dashboard_controller` 會重複建立 dashboard，且都用 id 96，導致 `dashboard_groups` 重複註冊 96。

根因在 `dashboard_id = 96` 寫死在 pname 迴圈**外面**，每次 DAG run 都從 96 重來。而且同名 pname 走 `continue` 時會跳過迴圈尾端的 `+= 1`，所以下一個新的災害專案照樣拿到 96。

`+= 1` 也解決不了：96 後面的號碼是別的 dashboard 在用（97 metro、98 traffic、99 youbike…），遞增只會撞進正常的 dashboard。

另外寫死 id 不會推進 `dashboards_id_seq`，之後從管理介面建 dashboard 也可能撞到同一個號。

## 改法

INSERT 不再帶 `id` 欄位，交給 `dashboards_id_seq` 配號，再用 `RETURNING` 把資料庫實際配到的 id 寫進 `dashboard_groups`。兩張表包在同一句 CTE、同一個交易裡，不會出現 dashboard 建好但關聯沒寫進去的半套狀態。

`ON CONFLICT DO NOTHING` 一併移除——新配的 id 不可能衝突。淨減 3 行。

## 驗證

本機用 Homebrew Postgres 14 起臨時實例，建與正式環境相同的 schema（`dashboards` serial PK、`dashboard_groups` 複合 PK + FK），先放一列 id 96 並把 sequence 設到 359，再從檔案解析出實際的 SQL 與 handler 連跑三次：

- 取得 360、361、362，既有的 96 完全不動
- `dashboard_groups` 只多對應的三列

## 正式環境已同步處理（不在本 PR 範圍）

`dashboards` 原本缺少約束，才讓舊程式塞得進重複的 96。已直接在 DB 補上，與 `Taipei-City-Dashboard-BE/app/models/dashboard.go` 的 model 定義一致（gorm AutoMigrate 不會替既有的表補 PK）：

- `dashboards_pkey` PRIMARY KEY (id)
- `dashboards_index_key` UNIQUE (index)
- `dashboards_id_seq` 已 setval 對齊 MAX(id)

建議**先合併並部署本 PR**。若舊程式還在跑而 PK 已生效，下一個災害專案進來會直接 duplicate key 讓 task 紅掉。

## 已知但未處理

- 「無資料」清除路徑：兩句依名稱刪 dashboard 的 SQL 因 `%s` 佔位符搭配 dict 參數而永遠拋例外（被 `except: pass` 吃掉），且 regex `.*_.*$` 一旦修好會誤刪所有名稱含底線的 dashboard；孤兒 component 的 DELETE 被包在 `if dash_recs:` 內，永遠刪不到
- `eoc_disaster_summary` 共用同一份 query，每個災害 dashboard 看到的內容相同

🤖 Generated with [Claude Code](https://claude.com/claude-code)